### PR TITLE
Add Differential Privacy Tip implementation

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,8 @@ omit = venv/*,__pycache__/*,*_test.py,*site-packages*
 
 [report]
 exclude_lines =
+    @abstractmethod
+    @abc.abstractmethod
     pragma: no cover
     def __repr__
     raise NotImplementedError

--- a/tips/differential_privacy.py
+++ b/tips/differential_privacy.py
@@ -164,7 +164,7 @@ class SecureLaplaceMechanism(LaplaceMechanism):
 
         # note this is where we rely on `value` being an integer.
         if granularity <= 1:
-            return round(noise * granularity)
+            return value + round(noise * granularity)
         else:
             granularity = int(granularity)
             rounded = granularity * (

--- a/tips/differential_privacy.py
+++ b/tips/differential_privacy.py
@@ -134,9 +134,12 @@ class LaplaceMechanism(ABC):
 
 
 class InsecureLaplaceMechanism(LaplaceMechanism):
+    def __init__(self, rng=None):
+        self.rng = rng or np.random.default_rng(1)
+
     def add_noise(self, value: int, privacy_parameter: float, sensitivity: float) -> int:
         scale = sensitivity / privacy_parameter
-        return value + round(np.random.default_rng().laplace(0, scale, 1)[0])
+        return value + round(self.rng.laplace(0, scale, 1)[0])
 
 
 class SecureLaplaceMechanism(LaplaceMechanism):

--- a/tips/differential_privacy.py
+++ b/tips/differential_privacy.py
@@ -1,0 +1,44 @@
+'''An implementation of the Laplacian mechanism for privately releasing a
+histogram where each underlying user contributes to a single bin.'''
+
+from typing import List
+
+from abc import ABC, abstractmethod
+
+
+Histogram = List[int]
+
+
+class LaplaceGenerator(ABC):
+    '''An interface for a random number generator that generates 0-mean
+    Laplacian noise, i.e., with density h(y) proportional to exp(−|y|/scale),
+    where scale is a parameter.
+    '''
+    @abstractmethod
+    def sample(self, scale) -> float:
+        ...
+
+
+def privatize_histogram(
+        hist: Histogram,
+        privacy_parameter: float,
+        rng: LaplaceGenerator):
+    '''Privatize a histogram for public release.
+
+    This implementation relies on the following properties:
+
+     - Each user contributes at most a count of one to at most one bin.
+     - The categories (bin definitions) of the histogram are fixed and public.
+
+    If these are satisfied, then the mechanism satsifies epsilon-differential
+    privacy for epsilon = `privacy_parameter`, meaning that if any individual
+    is removed from the dataset, the probability of this mechanism producing a
+    different output is at most exp(privacy_parameter). This limits the amount
+    of information any attacker (using any method or extra side data) can learn
+    about one individual in the dataset.
+    '''
+    # TODO: get a secure RNG
+    laplace_scale = 1 / privacy_parameter
+    noisy_hist = [bin_value + rng.sample(laplace_scale) for bin_value in hist]
+    rounded_noisy_hist = [max(0, round(val)) for val in noisy_hist]
+    return rounded_noisy_hist

--- a/tips/differential_privacy.py
+++ b/tips/differential_privacy.py
@@ -168,7 +168,7 @@ class SecureLaplaceMechanism(LaplaceMechanism):
         else:
             granularity = int(granularity)
             rounded = granularity * (
-                int(value / granularity) + round((value % granularity) / granularity)
+                value // granularity + round((value % granularity) / granularity)
             )
             return rounded + noise * granularity
 

--- a/tips/differential_privacy.py
+++ b/tips/differential_privacy.py
@@ -158,7 +158,7 @@ class SecureLaplaceMechanism(LaplaceMechanism):
 
     def add_noise(self, value: int, privacy_parameter: float, sensitivity: float) -> int:
         eps = privacy_parameter
-        granularity = next_power_of_two((1 / eps) / self.GRANULARITY_PARAM)
+        granularity = next_power_of_two((sensitivity / eps) / self.GRANULARITY_PARAM)
         noise = sample_two_sided_geometric(
             self.rng, granularity * eps / (sensitivity + granularity))
 

--- a/tips/differential_privacy.py
+++ b/tips/differential_privacy.py
@@ -184,3 +184,10 @@ def privatize_histogram(
         for bin_value in hist
     ]
     return [max(0, val) for val in noisy_hist]
+
+
+if __name__ == "__main__":
+    import cProfile
+    cProfile.run(
+        'for i in range(100000): '
+        'privatize_histogram((17,), math.log(3), SecureLaplaceMechanism(random.SystemRandom()))')

--- a/tips/differential_privacy.py
+++ b/tips/differential_privacy.py
@@ -41,7 +41,6 @@ def next_power_of_two(x: float) -> float:
 
 
 def sample_geometric(rng, exponent):
-    ...
     """ Returns a sample drawn from the geometric distribution of parameter p =
     1 - e^-exponent, i.e., the number of Bernoulli trials until the first
     success where the success probability is 1 - e^-exponent.
@@ -49,7 +48,7 @@ def sample_geometric(rng, exponent):
 
     max_value = 1 << 64
     # Return truncated sample in the case that the sample exceeds the max value.
-    if (rng.nextDouble() > -1.0 * math.expm1(-1.0 * exponent * max_value)):
+    if (rng.random() > -1.0 * math.expm1(-1.0 * exponent * max_value)):
         return max_value
 
     # Perform a binary search for the sample in the interval from 1 to max long. Each iteration
@@ -83,7 +82,7 @@ def sample_geometric(rng, exponent):
         # where X denotes the sample. The value of q should be approximately
         # one half.
         q = math.expm1(exponent * (left - mid)) / math.expm1(exponent * (left - right))
-        if (rng.nextDouble() <= q):
+        if (rng.random() <= q):
             right = mid
         else:
             left = mid
@@ -104,7 +103,7 @@ def sample_two_sided_geometric(rng, exponent):
     # probability of 0 would be twice as high as it should be.
     while (geometric_sample == 0 and not sign):
         geometric_sample = sample_geometric(rng, exponent) - 1
-        sign = rng.nextBoolean()
+        sign = rng.random() < 0.5
 
     return geometric_sample if sign else -geometric_sample
 

--- a/tips/differential_privacy_test.py
+++ b/tips/differential_privacy_test.py
@@ -67,6 +67,17 @@ def neighboring_histograms(draw, elements, min_size=1, max_size=10):
     return (hist1, hist2)
 
 
+@given(st.floats(
+    min_value=0.0, max_value=2**1023, allow_infinity=False, allow_nan=False, exclude_min=True
+))
+@example(float(2**-1023))
+@example(float(2**1023))
+def test_next_power_of_two(x):
+    output = next_power_of_two(x)
+    expected = min(float(2**i) for i in range(-1022, 1024) if 2**i >= x)
+    assert expected == output
+
+
 def test_privatize_single_number():
     number, privacy_parameter = 17, 0.5
 

--- a/tips/differential_privacy_test.py
+++ b/tips/differential_privacy_test.py
@@ -98,6 +98,14 @@ def test_sample_geometric_truncation():
     assert sample_geometric(random.Random(1), 1e-100) == 1 << 64
 
 
+def test_large_granularity():
+    mechanism = SecureLaplaceMechanism(random.Random(1))
+    output = mechanism.add_noise(11, 0.3, 1 << 40)  # results in a ganularity of 4
+    # This proves that when the granularity is large, the value is first
+    # rounded to a multiple of granularity before the noise is added.
+    assert output[0] == 12
+
+
 @pytest.mark.parametrize("name,mechanism", make_mechanisms())
 def test_privatize_single_number(name, mechanism):
     number, privacy_parameter = 17, 0.5

--- a/tips/differential_privacy_test.py
+++ b/tips/differential_privacy_test.py
@@ -16,6 +16,44 @@ class NumpyLaplaceGenerator(LaplaceGenerator):
         return np.random.default_rng().laplace(0, scale, 1)[0]
 
 
+def distributions_are_close(hist1, hist2, L2_tolerance):
+    '''
+     Decides whether two sets of random samples were likely drawn from similar
+     discrete distributions.
+
+     The distributions are considered similar if the l2 distance between them
+     is less than half the specified l2 tolerance t. Otherwise, if the distance
+     is greater than t, they are considered dissimilar. The error probability
+     is at most 4014 / (n * t^2), where n is the number of samples contained in
+     one of the sets. See https://arxiv.org/abs/1611.03579 for more
+     information, "Collision-based Testers are Optimal for Uniformity and
+     Closeness," by Ilias Diakonikolas, Themis Gouleakis, John Peebles, and
+     Eric Price.
+
+    Arguments:
+      - hist1: a dictionary whose keys are sample outcomes and whose values are
+          the frequency of the outcome in the sample, for one of the two
+          distributions being compared.
+      - hist2: same as hist1, but for a sample from the other distribution.
+      - L2_tolerance: the L2 distance between the underlying distributions, above which
+          the distributions are considered dissimilar. Lower tolerance requires
+          more samples to match the increased likelihood of error (even when
+          given two samples from the same distribution).
+
+    Returns True if the underlying distributions are within the given L2 distance.
+    '''
+    n = sum(hist1.values())
+    assert(n) == sum(hist2.values())
+
+    self_collision_1 = sum(count * (count - 1) / 2 for count in hist1.values())
+    self_collision_2 = sum(count * (count - 1) / 2 for count in hist2.values())
+    cross_collision_count = sum(hist1[sample] * hist2.get(sample, 0) for sample in hist1.keys())
+
+    test_value = (self_collision_1 + self_collision_2 - ((n - 1) / n) * cross_collision_count)
+    threshold = (L2_tolerance * (n - 1)) * (L2_tolerance * n) / 4.0
+    return test_value < threshold
+
+
 @st.composite
 def neighboring_histograms(draw, elements, min_size=1, max_size=10):
     hist = draw(st.lists(elements, min_size=min_size, max_size=max_size))
@@ -29,13 +67,30 @@ def neighboring_histograms(draw, elements, min_size=1, max_size=10):
     return (hist1, hist2)
 
 
+def test_privatize_single_number():
+    number, privacy_parameter = 17, 0.5
+
+    rng = NumpyLaplaceGenerator()
+    sample_size = 100000
+
+    def sample(num):
+        return Counter(
+            [privatize_histogram([num], privacy_parameter, rng)[0]
+             for _ in range(sample_size)])
+
+    sample_outputs = sample(number)
+    baseline = Counter([max(0, round(x)) for x in np.random.default_rng().laplace(
+        17, 1.0 / privacy_parameter, sample_size)])
+    assert distributions_are_close(sample_outputs, baseline, 1e-02)
+
+
 # @given(neighboring_histograms(st.integers(min_value=0, max_value=100)),
 #        st.floats(min_value=0.001, max_value=0.5, allow_infinity=False,
 #                  allow_nan=False),
 #         )
 # @example(((1, 2, 1, 2), (1, 2, 2, 2)), 0.5)
 def test_privatize_histogram():  # neighboring_hists, privacy_parameter):
-    neighboring_hists, privacy_parameter = ((1,), (2,)), math.log(3)
+    neighboring_hists, privacy_parameter = ((17,), (18,)), 0.5
 
     rng = NumpyLaplaceGenerator()
     hist1, hist2 = neighboring_hists
@@ -49,9 +104,16 @@ def test_privatize_histogram():  # neighboring_hists, privacy_parameter):
     sample_hist1 = sample(hist1)
     sample_hist2 = sample(hist2)
 
+    plot1 = [sample_hist1.get((i,), 0) for i in range(40)]
+    plot2 = [sample_hist2.get((i,), 0) for i in range(40)]
+    print(f'{plot1}')
+    print(f'{plot2}')
+
     def dp_test_statistic(s1, s2):
+        n = sum(s1.values())
+        assert n == sum(s2.values())
         return sum(
-            max(0.0, (s1[k] - math.exp(privacy_parameter) * s2.get(k, 0)) / len(s1))
+            max(0.0, (s1[k] - math.exp(privacy_parameter) * s2.get(k, 0)) / n)
             for k in s1.keys()
         )
 
@@ -59,5 +121,5 @@ def test_privatize_histogram():  # neighboring_hists, privacy_parameter):
     test_stat2 = dp_test_statistic(sample_hist2, sample_hist1)
 
     tolerance = 0.0025
-    assert test_stat1 < tolerance 
+    assert test_stat1 < tolerance
     assert test_stat2 < tolerance

--- a/tips/differential_privacy_test.py
+++ b/tips/differential_privacy_test.py
@@ -139,6 +139,7 @@ def test_privatize_single_bin_histogram(name, mechanism):
 @pytest.mark.parametrize("name,mechanism", make_mechanisms())
 @pytest.mark.parametrize("neighboring_hists", [
     ((1, 2, 1, 2), (1, 2, 2, 2)),
+    ((10, 15, 9, 14), (9, 15, 9, 14)),
 ])
 def test_privatize_multi_bin_histogram(name, mechanism, neighboring_hists):
     privacy_parameter = math.log(3)

--- a/tips/differential_privacy_test.py
+++ b/tips/differential_privacy_test.py
@@ -12,6 +12,7 @@ from differential_privacy import InsecureLaplaceMechanism
 from differential_privacy import SecureLaplaceMechanism
 from differential_privacy import next_power_of_two
 from differential_privacy import privatize_histogram
+from differential_privacy import sample_geometric
 
 
 def distributions_are_close(hist1, hist2, L2_tolerance):
@@ -91,6 +92,10 @@ def test_next_power_of_two(x):
     output = next_power_of_two(x)
     expected = min(float(2**i) for i in range(-1022, 1024) if 2**i >= x)
     assert expected == output
+
+
+def test_sample_geometric_truncation():
+    assert sample_geometric(random.Random(1), 1e-100) == 1 << 64
 
 
 @pytest.mark.parametrize("name,mechanism", make_mechanisms())

--- a/tips/differential_privacy_test.py
+++ b/tips/differential_privacy_test.py
@@ -104,8 +104,8 @@ def test_privatize_single_number(name, mechanism):
              for _ in range(sample_size)])
 
     sample_outputs = sample(number)
-    baseline = Counter([max(0, round(x)) for x in np.random.default_rng().laplace(
-        17, 1.0 / privacy_parameter, sample_size)])
+    baseline = Counter([max(0, round(x)) for x in np.random.default_rng(1).laplace(
+        number, 1.0 / privacy_parameter, sample_size)])
     assert distributions_are_close(sample_outputs, baseline, 1e-02)
 
 

--- a/tips/differential_privacy_test.py
+++ b/tips/differential_privacy_test.py
@@ -1,0 +1,63 @@
+import math
+from collections import Counter
+from collections import defaultdict
+
+from hypothesis import strategies as st
+from hypothesis import given
+from hypothesis import example
+import numpy as np
+
+from differential_privacy import LaplaceGenerator
+from differential_privacy import privatize_histogram
+
+
+class NumpyLaplaceGenerator(LaplaceGenerator):
+    def sample(self, scale) -> float:
+        return np.random.default_rng().laplace(0, scale, 1)[0]
+
+
+@st.composite
+def neighboring_histograms(draw, elements, min_size=1, max_size=10):
+    hist = draw(st.lists(elements, min_size=min_size, max_size=max_size))
+    hist1 = tuple(hist)
+
+    index = draw(st.integers(min_value=0, max_value=len(hist) - 1))
+    change = draw(st.sampled_from([-1, 1]))
+    hist[index] += change
+    hist2 = tuple(hist)
+
+    return (hist1, hist2)
+
+
+# @given(neighboring_histograms(st.integers(min_value=0, max_value=100)),
+#        st.floats(min_value=0.001, max_value=0.5, allow_infinity=False,
+#                  allow_nan=False),
+#         )
+# @example(((1, 2, 1, 2), (1, 2, 2, 2)), 0.5)
+def test_privatize_histogram():  # neighboring_hists, privacy_parameter):
+    neighboring_hists, privacy_parameter = ((1,), (2,)), math.log(3)
+
+    rng = NumpyLaplaceGenerator()
+    hist1, hist2 = neighboring_hists
+    sample_size = 200000
+
+    def sample(hist):
+        return Counter(
+            [tuple(privatize_histogram(hist, privacy_parameter, rng))
+             for _ in range(sample_size)])
+
+    sample_hist1 = sample(hist1)
+    sample_hist2 = sample(hist2)
+
+    def dp_test_statistic(s1, s2):
+        return sum(
+            max(0.0, (s1[k] - math.exp(privacy_parameter) * s2.get(k, 0)) / len(s1))
+            for k in s1.keys()
+        )
+
+    test_stat1 = dp_test_statistic(sample_hist1, sample_hist2)
+    test_stat2 = dp_test_statistic(sample_hist2, sample_hist1)
+
+    tolerance = 0.0025
+    assert test_stat1 < tolerance 
+    assert test_stat2 < tolerance

--- a/tips/differential_privacy_test.py
+++ b/tips/differential_privacy_test.py
@@ -1,19 +1,15 @@
 import math
 from collections import Counter
-from collections import defaultdict
 
 from hypothesis import strategies as st
 from hypothesis import given
 from hypothesis import example
 import numpy as np
 
-from differential_privacy import LaplaceGenerator
+from differential_privacy import InsecureLaplaceMechanism
 from differential_privacy import privatize_histogram
+from differential_privacy import next_power_of_two
 
-
-class NumpyLaplaceGenerator(LaplaceGenerator):
-    def sample(self, scale) -> float:
-        return np.random.default_rng().laplace(0, scale, 1)[0]
 
 
 def distributions_are_close(hist1, hist2, L2_tolerance):
@@ -56,6 +52,8 @@ def distributions_are_close(hist1, hist2, L2_tolerance):
 
 @st.composite
 def neighboring_histograms(draw, elements, min_size=1, max_size=10):
+    """Generate two neighboring histograms, i.e., two histograms that differ by
+    1 in a single bin."""
     hist = draw(st.lists(elements, min_size=min_size, max_size=max_size))
     hist1 = tuple(hist)
 
@@ -81,7 +79,7 @@ def test_next_power_of_two(x):
 def test_privatize_single_number():
     number, privacy_parameter = 17, 0.5
 
-    rng = NumpyLaplaceGenerator()
+    rng = InsecureLaplaceMechanism()
     sample_size = 100000
 
     def sample(num):
@@ -101,9 +99,9 @@ def test_privatize_single_number():
 #         )
 # @example(((1, 2, 1, 2), (1, 2, 2, 2)), 0.5)
 def test_privatize_histogram():  # neighboring_hists, privacy_parameter):
-    neighboring_hists, privacy_parameter = ((17,), (18,)), 0.5
+    neighboring_hists, privacy_parameter = ((17,), (18,)), math.log(3)
 
-    rng = NumpyLaplaceGenerator()
+    rng = InsecureLaplaceMechanism()
     hist1, hist2 = neighboring_hists
     sample_size = 200000
 

--- a/tips/differential_privacy_test.py
+++ b/tips/differential_privacy_test.py
@@ -134,3 +134,29 @@ def test_privatize_single_bin_histogram(name, mechanism):
     tolerance = 0.0025
     assert test_stat1 < tolerance
     assert test_stat2 < tolerance
+
+
+@pytest.mark.parametrize("name,mechanism", make_mechanisms())
+@pytest.mark.parametrize("neighboring_hists", [
+    ((1, 2, 1, 2), (1, 2, 2, 2)),
+])
+def test_privatize_multi_bin_histogram(name, mechanism, neighboring_hists):
+    privacy_parameter = math.log(3)
+    mechanism = InsecureLaplaceMechanism()
+    hist1, hist2 = neighboring_hists
+    sample_size = 250000
+
+    def sample(hist):
+        return Counter(
+            [tuple(privatize_histogram(hist, privacy_parameter, mechanism))
+             for _ in range(sample_size)])
+
+    sample_hist1 = sample(hist1)
+    sample_hist2 = sample(hist2)
+
+    test_stat1 = dp_test_statistic(sample_hist1, sample_hist2, privacy_parameter)
+    test_stat2 = dp_test_statistic(sample_hist2, sample_hist1, privacy_parameter)
+
+    tolerance = 0.05
+    assert test_stat1 < tolerance
+    assert test_stat2 < tolerance

--- a/tips/differential_privacy_test.py
+++ b/tips/differential_privacy_test.py
@@ -113,7 +113,7 @@ def test_privatize_single_number(name, mechanism):
 def test_privatize_single_bin_histogram(name, mechanism):
     neighboring_hists, privacy_parameter = ((17,), (18,)), math.log(3)
     hist1, hist2 = neighboring_hists
-    sample_size = 200000
+    sample_size = 500000
 
     def sample(hist):
         return Counter(

--- a/tips/differential_privacy_test.py
+++ b/tips/differential_privacy_test.py
@@ -113,7 +113,7 @@ def test_privatize_single_number(name, mechanism):
 def test_privatize_single_bin_histogram(name, mechanism):
     neighboring_hists, privacy_parameter = ((17,), (18,)), math.log(3)
     hist1, hist2 = neighboring_hists
-    sample_size = 500000
+    sample_size = 600000
 
     def sample(hist):
         return Counter(


### PR DESCRIPTION
An implementation of a secure Laplace mechanism (ported from Google's implementation) for masking a histogram of integers to be epsilon-differentially private, with the caveat that it hard-codes a sensitivity of 1 and only works for integral values in each bin.

Also includes some nontrivial testing facilities to compare samples from two distributions, and property test approximate epsilon-delta differential privacy.